### PR TITLE
Fix docstring newlines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sob"
-version = "2.2.0"
+version = "2.2.1"
 description = "A type-enforced framework for serializing and deserializing JSON"
 readme = "README.md"
 license = "MIT"
@@ -48,7 +48,7 @@ dependencies = [
     "pytest",
     "mypy",
     "dependence~=1.1",
-    "gittable~=0.0",
+    "gittable~=0.2",
 ]
 pre-install-commands = [
     "pip install --upgrade pip setuptools",

--- a/src/sob/utilities.py
+++ b/src/sob/utilities.py
@@ -485,7 +485,9 @@ def split_long_docstring_lines(
     indent_: str = "    "
     if "\t" in docstring:
         docstring = docstring.replace("\t", indent_)
-    lines: list[str] = docstring.split("\n")
+    lines: list[str] = (
+        docstring.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    )
     indentation_length: int = sys.maxsize
     for line in filter(None, lines):
         matched = re.match(r"^[ ]+", line)


### PR DESCRIPTION
### 1. `pyproject.toml`                                                                                                                                                        
   
  | Change | Before | After |                                                                                                                                                    
  |--------|--------|-------|
  | Version bump | `2.2.0` | `2.2.1` |                                                                                                                                           
  | Dev dependency | `gittable~=0.0` | `gittable~=0.2` |                                                                                                                         
                                                                                                                                                                                 
  ### 2. `src/sob/utilities.py` (line ~488)                                                                                                                                      
                                                                                                                                                                                 
  The core fix — `split_long_docstring_lines` previously split on `"\n"` only. The fix normalizes all line-ending variants before splitting:                                     
                  
  **Before:**                                                                                                                                                                    
                  
  ```python                                                                                                                                                                      
  lines: list[str] = docstring.split("\n")
                                                                                                                                                                                 
  After:                                                                                                                                                                         
                                                                                                                                                                                 
  lines: list[str] = (                                                                                                                                                           
      docstring.replace("\r\n", "\n").replace("\r", "\n").split("\n")                                                                                                            
  )   